### PR TITLE
chore: rename df variables in test files for consistency

### DIFF
--- a/tests/integration/test_build_staging.py
+++ b/tests/integration/test_build_staging.py
@@ -51,7 +51,7 @@ def project_id():
 
 
 @pytest.fixture(scope="module")
-def raw_df(bq_client, project_id):
+def raw_contributions(bq_client, project_id):
     """Load raw data for the test execution date."""
     return load_raw_data(bq_client, project_id, TEST_EXECUTION_DATE)
 
@@ -60,58 +60,58 @@ def raw_df(bq_client, project_id):
 # Unit-style tests (no BigQuery required)
 # ---------------------------------------------------------------------------
 
-def test_apply_normalization_name(raw_df):
+def test_apply_normalization_name(raw_contributions):
     """donor_name_normalized is lowercase with no punctuation."""
-    df = apply_normalization(raw_df)
-    assert "donor_name_normalized" in df.columns
+    normalized = apply_normalization(raw_contributions)
+    assert "donor_name_normalized" in normalized.columns
     # No uppercase characters
-    assert df["donor_name_normalized"].str.contains(r"[A-Z]").sum() == 0
+    assert normalized["donor_name_normalized"].str.contains(r"[A-Z]").sum() == 0
     # No commas
-    assert df["donor_name_normalized"].str.contains(",").sum() == 0
+    assert normalized["donor_name_normalized"].str.contains(",").sum() == 0
 
 
-def test_apply_normalization_zip(raw_df):
+def test_apply_normalization_zip(raw_contributions):
     """zip_normalized is always 5 digits."""
-    df = apply_normalization(raw_df)
-    assert "zip_normalized" in df.columns
-    non_empty = df["zip_normalized"][df["zip_normalized"] != ""]
+    normalized = apply_normalization(raw_contributions)
+    assert "zip_normalized" in normalized.columns
+    non_empty = normalized["zip_normalized"][normalized["zip_normalized"] != ""]
     assert (non_empty.str.len() == 5).all(), (
         "All non-empty ZIP codes must be exactly 5 digits"
     )
 
 
-def test_apply_normalization_address(raw_df):
+def test_apply_normalization_address(raw_contributions):
     """donor_address_normalized is lowercase."""
-    df = apply_normalization(raw_df)
-    assert "donor_address_normalized" in df.columns
-    non_empty = df["donor_address_normalized"][df["donor_address_normalized"] != ""]
+    normalized = apply_normalization(raw_contributions)
+    assert "donor_address_normalized" in normalized.columns
+    non_empty = normalized["donor_address_normalized"][normalized["donor_address_normalized"] != ""]
     assert non_empty.str.contains(r"[A-Z]").sum() == 0
 
 
-def test_apply_normalization_address_includes_state(raw_df):
+def test_apply_normalization_address_includes_state(raw_contributions):
     """donor_address_normalized includes both city and state."""
-    df = apply_normalization(raw_df)
+    normalized = apply_normalization(raw_contributions)
     # Address should contain a space (city + state)
-    non_empty = df["donor_address_normalized"][df["donor_address_normalized"] != ""]
+    non_empty = normalized["donor_address_normalized"][normalized["donor_address_normalized"] != ""]
     assert non_empty.str.contains(" ").any(), (
         "donor_address_normalized appears to contain only city — state may be missing"
     )
 
 
-def test_filter_individuals_removes_non_ind(raw_df):
+def test_filter_individuals_removes_non_ind(raw_contributions):
     """Only IND entity type records pass the filter."""
-    df = filter_individuals(raw_df)
-    assert (df["ENTITY_TP"] == "IND").all(), (
+    filtered = filter_individuals(raw_contributions)
+    assert (filtered["ENTITY_TP"] == "IND").all(), (
         "Non-IND records found after filter"
     )
 
 
-def test_parse_contribution_date(raw_df):
+def test_parse_contribution_date(raw_contributions):
     """TRANSACTION_DT is parsed from MMDDYYYY to YYYY-MM-DD string."""
-    df = parse_contribution_date(raw_df)
-    assert "contribution_date" in df.columns
+    parsed = parse_contribution_date(raw_contributions)
+    assert "contribution_date" in parsed.columns
     # Verify format is YYYY-MM-DD on a non-null sample
-    sample = df["contribution_date"].dropna().iloc[0]
+    sample = parsed["contribution_date"].dropna().iloc[0]
     assert len(sample) == 10, f"Expected YYYY-MM-DD format, got: {sample}"
     assert sample[4] == "-" and sample[7] == "-", (
         f"Expected YYYY-MM-DD format, got: {sample}"

--- a/tests/integration/test_load_raw_fec.py
+++ b/tests/integration/test_load_raw_fec.py
@@ -94,25 +94,25 @@ def test_fixture_file_exists():
 
 
 def test_load_csv_to_dataframe():
-    df = load_csv_to_dataframe(FIXTURE_PATH)
+    raw_contributions = load_csv_to_dataframe(FIXTURE_PATH)
     expected = get_fixture_row_count()
-    assert len(df) == expected, f"Expected {expected} rows, got {len(df)}"
+    assert len(raw_contributions) == expected, f"Expected {expected} rows, got {len(raw_contributions)}"
 
 
 
 def test_add_load_date_column():
     """_load_date column is added with correct value."""
-    df = load_csv_to_dataframe(FIXTURE_PATH)
-    df = add_load_date_column(df, TEST_EXECUTION_DATE)
-    assert "_load_date" in df.columns
-    assert df["_load_date"].iloc[0] == TEST_EXECUTION_DATE
+    raw_contributions = load_csv_to_dataframe(FIXTURE_PATH)
+    raw_contributions = add_load_date_column(raw_contributions, TEST_EXECUTION_DATE)
+    assert "_load_date" in raw_contributions.columns
+    assert raw_contributions["_load_date"].iloc[0] == TEST_EXECUTION_DATE
 
 
 def test_load_date_is_same_for_all_rows():
     """Every row gets the same _load_date."""
-    df = load_csv_to_dataframe(FIXTURE_PATH)
-    df = add_load_date_column(df, TEST_EXECUTION_DATE)
-    assert df["_load_date"].nunique() == 1
+    raw_contributions = load_csv_to_dataframe(FIXTURE_PATH)
+    raw_contributions = add_load_date_column(raw_contributions, TEST_EXECUTION_DATE)
+    assert raw_contributions["_load_date"].nunique() == 1
 
 
 def test_missing_execution_date_fails():
@@ -136,9 +136,9 @@ def test_missing_execution_date_fails():
 
 def test_load_to_bigquery_succeeds(bq_client, project_id):
     """Fixture CSV loads into BigQuery test table without error."""
-    df = load_csv_to_dataframe(FIXTURE_PATH)
-    df = add_load_date_column(df, TEST_EXECUTION_DATE)
-    load_to_bigquery(df, project_id, TEST_TABLE_ID, TEST_EXECUTION_DATE, bq_client)
+    raw_contributions = load_csv_to_dataframe(FIXTURE_PATH)
+    raw_contributions = add_load_date_column(raw_contributions, TEST_EXECUTION_DATE)
+    load_to_bigquery(raw_contributions, project_id, TEST_TABLE_ID, TEST_EXECUTION_DATE, bq_client)
 
     count = count_rows_in_partition(
         bq_client, project_id, TEST_TABLE_ID, TEST_EXECUTION_DATE
@@ -164,13 +164,13 @@ def test_row_count_matches_fixture(bq_client, project_id):
 
 def test_idempotency_no_duplicates_on_rerun(bq_client, project_id):
     """Running the load twice for the same date does not duplicate rows."""
-    df = load_csv_to_dataframe(FIXTURE_PATH)
-    df = add_load_date_column(df, TEST_EXECUTION_DATE)
+    raw_contributions = load_csv_to_dataframe(FIXTURE_PATH)
+    raw_contributions = add_load_date_column(raw_contributions, TEST_EXECUTION_DATE)
 
     # Run once
-    load_to_bigquery(df, project_id, TEST_TABLE_ID, TEST_EXECUTION_DATE, bq_client)
+    load_to_bigquery(raw_contributions, project_id, TEST_TABLE_ID, TEST_EXECUTION_DATE, bq_client)
     # Run again
-    load_to_bigquery(df, project_id, TEST_TABLE_ID, TEST_EXECUTION_DATE, bq_client)
+    load_to_bigquery(raw_contributions, project_id, TEST_TABLE_ID, TEST_EXECUTION_DATE, bq_client)
 
     count = count_rows_in_partition(
         bq_client, project_id, TEST_TABLE_ID, TEST_EXECUTION_DATE


### PR DESCRIPTION
- test_build_staging.py: raw_df fixture -> raw_contributions
- test_build_staging.py: df results -> normalized, filtered, parsed
- test_load_raw_fec.py: df -> raw_contributions throughout
- Consistent with df naming standards applied across pipeline code
- 180/180 tests passing